### PR TITLE
Add modular courses feature

### DIFF
--- a/Pepe-Hxr-Clases/src/App.tsx
+++ b/Pepe-Hxr-Clases/src/App.tsx
@@ -3,6 +3,8 @@ import React, { useState, useEffect, useRef } from 'react';
 import CourseCard from './components/CourseCards';
 import EnhancedPlayer from './components/EnhancedPlayer';
 import WriteUpsSection from './components/WriteUpsSection';
+import ModularCourses from './components/ModularCourses';
+import { ModularCourse } from './types';
 
 import logoClase1 from './assets/logos/arquitecturadecomputadoraslogo.jpg';
 import logoClase2 from './assets/logos/Anonimato.jpg';
@@ -63,6 +65,28 @@ const App: React.FC = () => {
     },
   ];
 
+  const modularCourses: ModularCourse[] = [
+    {
+      title: 'Curso Hacking Básico',
+      image: logoClase1,
+      modules: [
+        {
+          name: 'Módulo 1',
+          classes: [
+            { title: 'Introducción', videoUrl: 'https://youtu.be/WasDk4qlD1c' },
+            { title: 'Herramientas', videoUrl: 'https://youtu.be/lLMM7CdhgEk' },
+          ],
+        },
+        {
+          name: 'Módulo 2',
+          classes: [
+            { title: 'Escaneo de puertos', videoUrl: 'https://youtu.be/pknxAdkG5C0' },
+          ],
+        },
+      ],
+    },
+  ];
+
   /* ------------- handlers ------------- */
   const handleAudioUpload = (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];
@@ -74,6 +98,13 @@ const App: React.FC = () => {
 
   const handleQualityChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
     setVideoQuality(e.target.value);
+  };
+
+  const handleSelectModularClass = (url: string) => {
+    setVideoUrl(url);
+    setAudioUrl('');
+    setDescription('');
+    setUseCustomAudio(false);
   };
 
   // Efecto para manejar el video de fondo
@@ -339,6 +370,8 @@ const App: React.FC = () => {
               </div>
             </>
           )}
+
+          <ModularCourses courses={modularCourses} onSelectClass={handleSelectModularClass} />
 
           {/* --------- APARTADO WRITE-UPS --------- */}
                   <WriteUpsSection />

--- a/Pepe-Hxr-Clases/src/components/ModularCourses.tsx
+++ b/Pepe-Hxr-Clases/src/components/ModularCourses.tsx
@@ -1,0 +1,88 @@
+import React, { useState } from 'react';
+import CourseCard from './CourseCards';
+import { ModularCourse } from '../types';
+
+interface Props {
+  courses: ModularCourse[];
+  onSelectClass: (videoUrl: string) => void;
+}
+
+const ModularCourses: React.FC<Props> = ({ courses, onSelectClass }) => {
+  const [selected, setSelected] = useState<ModularCourse | null>(null);
+
+  if (selected) {
+    return (
+      <div style={{ marginTop: 40 }}>
+        <button
+          onClick={() => setSelected(null)}
+          style={{
+            marginBottom: 20,
+            background: '#444',
+            color: '#fff',
+            border: 'none',
+            borderRadius: 8,
+            padding: '8px 16px',
+            cursor: 'pointer',
+          }}
+        >
+          Volver
+        </button>
+        <h2 style={{ color: '#fff', marginBottom: 20 }}>{selected.title}</h2>
+        {selected.modules.map((mod, idx) => (
+          <div key={idx} style={{ marginBottom: 30 }}>
+            <h3 style={{ color: '#fff', marginBottom: 10 }}>{mod.name}</h3>
+            <ul style={{ listStyle: 'none', padding: 0, display: 'flex', flexDirection: 'column', gap: 10 }}>
+              {mod.classes.map((cl, i) => (
+                <li key={i}>
+                  <button
+                    onClick={() => onSelectClass(cl.videoUrl)}
+                    style={{
+                      background: '#333',
+                      color: '#fff',
+                      border: 'none',
+                      borderRadius: 8,
+                      padding: '8px 12px',
+                      cursor: 'pointer',
+                    }}
+                  >
+                    {cl.title}
+                  </button>
+                </li>
+              ))}
+            </ul>
+          </div>
+        ))}
+      </div>
+    );
+  }
+
+  return (
+    <div style={{ marginTop: 60 }}>
+      <h2 style={{ color: '#fff', marginBottom: 20 }}>Cursos modulares</h2>
+      <div
+        style={{
+          display: 'flex',
+          flexWrap: 'wrap',
+          justifyContent: 'center',
+          gap: '40px',
+        }}
+      >
+        {courses.map((c, i) => (
+          <div key={i} style={{ width: '260px' }}>
+            <CourseCard
+              course={{
+                title: c.title,
+                image: c.image,
+                videoUrl: '',
+                description: c.description || '',
+              }}
+              onSelect={() => setSelected(c)}
+            />
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+};
+
+export default ModularCourses;

--- a/Pepe-Hxr-Clases/src/types.ts
+++ b/Pepe-Hxr-Clases/src/types.ts
@@ -5,3 +5,21 @@ export interface Course {
   videoUrl: string;
   description?: string; // opcional
 }
+
+export interface ModuleClass {
+  title: string;
+  videoUrl: string;
+  description?: string;
+}
+
+export interface Module {
+  name: string;
+  classes: ModuleClass[];
+}
+
+export interface ModularCourse {
+  title: string;
+  image: string;
+  modules: Module[];
+  description?: string;
+}


### PR DESCRIPTION
## Summary
- define interfaces for modular courses
- implement a `ModularCourses` component
- display the new modular courses section in the main app

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_683fe270f95883269671ba6a4312e1b5